### PR TITLE
Local date refactor

### DIFF
--- a/src/LocalDateTimeConverter/LocalDateTime.cpp
+++ b/src/LocalDateTimeConverter/LocalDateTime.cpp
@@ -1,12 +1,8 @@
 #include "LocalDateTime.h"
 
-LocalDateTime::LocalDateTime(unsigned long epochSeconds,
-                             unsigned long localSeconds) {
-  _epochSeconds = epochSeconds;
+LocalDateTime::LocalDateTime(unsigned long localSeconds) {
   _localSeconds = localSeconds;
 };
-
-unsigned long LocalDateTime::getEpochSeconds() { return this->_epochSeconds; };
 
 unsigned long LocalDateTime::getLocalSeconds() { return this->_localSeconds; };
 

--- a/src/LocalDateTimeConverter/LocalDateTime.h
+++ b/src/LocalDateTimeConverter/LocalDateTime.h
@@ -11,12 +11,11 @@
 class LocalDateTime {
 
 private:
-  unsigned long _epochSeconds;
   unsigned long _localSeconds;
 
 public:
-  LocalDateTime(unsigned long epochSeconds, unsigned long localSeconds);
-  unsigned long getEpochSeconds();
+  LocalDateTime(unsigned long localSeconds);
+
   unsigned long getLocalSeconds();
 
   int getLocalTimeFragment(int unit);

--- a/src/LocalDateTimeConverter/LocalDateTimeConverter.cpp
+++ b/src/LocalDateTimeConverter/LocalDateTimeConverter.cpp
@@ -38,7 +38,7 @@ LocalDateTime LocalDateTimeConverter::fromUtc(unsigned long epochSeconds) {
   } else {
     localSeconds = epochSeconds;
   }
-  return LocalDateTime(epochSeconds, localSeconds);
+  return LocalDateTime(localSeconds);
 }
 
 LocalDateTimeConverter LocalDateTimeConverter::UTC =

--- a/src/LocalDateTimeConverter/LocalDateTimeConverterTest.ino
+++ b/src/LocalDateTimeConverter/LocalDateTimeConverterTest.ino
@@ -3,6 +3,9 @@
 
 #include "LocalDateTimeConverter.h"
 
+// UTC seconds for 2022-02-14T12:34:56UTC
+unsigned long valentinesUTCSecond = 1644842096ul;
+
 test(epoch_start_test) {
   // given
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
@@ -22,11 +25,9 @@ test(valentines_day) {
   LocalDateTime valentinesInUTC = utc.fromUtc(2022, 2, 14, 12, 34, 56);
   LocalDateTime valentinesInPL = pl.fromUtc(2022, 2, 14, 12, 34, 56);
 
-  unsigned long expectedUTCSecond = 1644842096ul;
-
   // then
-  assertEqual(valentinesInUTC.getLocalSeconds(), expectedUTCSecond);
-  assertEqual(valentinesInPL.getLocalSeconds(), expectedUTCSecond + 3600);
+  assertEqual(valentinesInUTC.getLocalSeconds(), valentinesUTCSecond);
+  assertEqual(valentinesInPL.getLocalSeconds(), valentinesUTCSecond + 3600);
 }
 
 test(utc_conversion_to_seconds) {
@@ -34,7 +35,7 @@ test(utc_conversion_to_seconds) {
   LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
 
   assertEqual(utc.fromUtc(2022, 2, 14, 12, 34, 56).getLocalSeconds(),
-              1644842096ul);
+              valentinesUTCSecond);
   assertEqual(utc.fromUtc(2020, 2, 29, 0, 0, 0).getLocalSeconds(),
               1582934400ul);
   assertEqual(utc.fromUtc(2050, 8, 15, 17, 15, 0).getLocalSeconds(),
@@ -55,7 +56,7 @@ test(pl_conversion_to_seconds) {
   assertEqual(pl.fromUtc(0ul).getLocalSeconds(), 3600ul);
 
   assertEqual(pl.fromUtc(2022, 2, 14, 12, 34, 56).getLocalSeconds(),
-              1644842096ul + 3600);
+              valentinesUTCSecond + 3600);
   assertEqual(pl.fromUtc(2020, 2, 29, 0, 0, 0).getLocalSeconds(),
               1582934400ul + 3600);
   assertEqual(pl.fromUtc(2050, 8, 15, 17, 15, 0).getLocalSeconds(),
@@ -132,6 +133,7 @@ test(local_date_get_time_fragments_at_valentines_pl) {
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
   LocalDateTime valentines = pl.fromUtc(2022, 2, 14, 12, 34, 56);
 
+  // noon in UTC on valentines day is 1 pm in Poland
   assertEqual(valentines.getLocalTimeFragment(HOURS), 13);
   assertEqual(valentines.getLocalTimeFragment(MINUTES), 34);
   assertEqual(valentines.getLocalTimeFragment(SECONDS), 56);

--- a/src/LocalDateTimeConverter/LocalDateTimeConverterTest.ino
+++ b/src/LocalDateTimeConverter/LocalDateTimeConverterTest.ino
@@ -12,38 +12,33 @@ test(epoch_start_test) {
   LocalDateTime localDateTime = pl.fromUtc(epochStart);
 
   // then
-  assertEqual(localDateTime.getEpochSeconds(), epochStart);
   assertEqual(localDateTime.getLocalSeconds(), epochStart + 3600);
 }
 
 test(valentines_day) {
   // given
+  LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
-  LocalDateTime valentines = pl.fromUtc(2022, 2, 14, 12, 34, 56);
-  unsigned long expectedEpochSeconds = 1644842096ul;
+  LocalDateTime valentinesInUTC = utc.fromUtc(2022, 2, 14, 12, 34, 56);
+  LocalDateTime valentinesInPL = pl.fromUtc(2022, 2, 14, 12, 34, 56);
+
+  unsigned long expectedUTCSecond = 1644842096ul;
 
   // then
-  assertEqual(valentines.getEpochSeconds(), expectedEpochSeconds);
+  assertEqual(valentinesInUTC.getLocalSeconds(), expectedUTCSecond);
+  assertEqual(valentinesInPL.getLocalSeconds(), expectedUTCSecond + 3600);
 }
 
 test(utc_conversion_to_seconds) {
   // given
   LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
 
-  assertEqual(utc.fromUtc(2022, 2, 14, 12, 34, 56).getEpochSeconds(),
-              1644842096ul);
   assertEqual(utc.fromUtc(2022, 2, 14, 12, 34, 56).getLocalSeconds(),
               1644842096ul);
-  assertEqual(utc.fromUtc(2020, 2, 29, 0, 0, 0).getEpochSeconds(),
-              1582934400ul);
   assertEqual(utc.fromUtc(2020, 2, 29, 0, 0, 0).getLocalSeconds(),
               1582934400ul);
-  assertEqual(utc.fromUtc(2050, 8, 15, 17, 15, 0).getEpochSeconds(),
-              2544196500ul);
   assertEqual(utc.fromUtc(2050, 8, 15, 17, 15, 0).getLocalSeconds(),
               2544196500ul);
-  assertEqual(utc.fromUtc(2100, 8, 15, 17, 15, 0).getEpochSeconds(),
-              4122033300ul);
   assertEqual(utc.fromUtc(2100, 8, 15, 17, 15, 0).getLocalSeconds(),
               4122033300ul);
 
@@ -59,19 +54,12 @@ test(pl_conversion_to_seconds) {
   // epoch start
   assertEqual(pl.fromUtc(0ul).getLocalSeconds(), 3600ul);
 
-  assertEqual(pl.fromUtc(2022, 2, 14, 12, 34, 56).getEpochSeconds(),
-              1644842096ul);
   assertEqual(pl.fromUtc(2022, 2, 14, 12, 34, 56).getLocalSeconds(),
               1644842096ul + 3600);
-  assertEqual(pl.fromUtc(2020, 2, 29, 0, 0, 0).getEpochSeconds(), 1582934400ul);
   assertEqual(pl.fromUtc(2020, 2, 29, 0, 0, 0).getLocalSeconds(),
               1582934400ul + 3600);
-  assertEqual(pl.fromUtc(2050, 8, 15, 17, 15, 0).getEpochSeconds(),
-              2544196500ul);
   assertEqual(pl.fromUtc(2050, 8, 15, 17, 15, 0).getLocalSeconds(),
               2544196500ul + 7200);
-  assertEqual(pl.fromUtc(2100, 8, 15, 17, 15, 0).getEpochSeconds(),
-              4122033300ul);
   assertEqual(pl.fromUtc(2100, 8, 15, 17, 15, 0).getLocalSeconds(),
               4122033300ul + 7200);
 }
@@ -79,27 +67,34 @@ test(pl_conversion_to_seconds) {
 // in March we change the clock from 2 AM to 3 AM
 test(pl_conversion_near_spring_time_change_2020) {
   // given
+  LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
 
-  // before 1 AM UTC (before 2 AM CET)
-  LocalDateTime before = pl.fromUtc(2020, 3, 29, 0, 59, 0);
-  assertEqual(before.getLocalSeconds(), before.getEpochSeconds() + 3600);
-  // after 1 AM UTC (after 3 AM CET)
-  LocalDateTime after = pl.fromUtc(2020, 3, 29, 1, 1, 0);
-  assertEqual(after.getLocalSeconds(), after.getEpochSeconds() + 7200);
+  // local time before 1 AM UTC (before 2 AM CET)
+  LocalDateTime beforeUTC = utc.fromUtc(2020, 3, 29, 0, 59, 0);
+  LocalDateTime beforePL = pl.fromUtc(2020, 3, 29, 0, 59, 0);
+
+  assertEqual(beforePL.getLocalSeconds(), beforeUTC.getLocalSeconds() + 3600);
+  // local time after 1 AM UTC (after 3 AM CET)
+  LocalDateTime afterUTC = utc.fromUtc(2020, 3, 29, 1, 1, 0);
+  LocalDateTime afterPL = pl.fromUtc(2020, 3, 29, 1, 1, 0);
+  assertEqual(afterPL.getLocalSeconds(), afterUTC.getLocalSeconds() + 7200);
 }
 
 // in October we change the clock from 3 AM to 2 AM
 test(pl_conversion_near_autumn_time_change_2020) {
   // given
+  LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
 
-  // before 1 AM UTC (before 3 AM CEST)
-  LocalDateTime before = pl.fromUtc(2020, 10, 25, 0, 59, 0);
-  assertEqual(before.getLocalSeconds(), before.getEpochSeconds() + 7200);
-  // after 1 AM UTC (after 2 AM CEST)
-  LocalDateTime after = pl.fromUtc(2020, 10, 25, 1, 1, 0);
-  assertEqual(after.getLocalSeconds(), after.getEpochSeconds() + 3600);
+  // local time before 1 AM UTC (before 3 AM CEST)
+  LocalDateTime beforeUTC = utc.fromUtc(2020, 10, 25, 0, 59, 0);
+  LocalDateTime beforePL = pl.fromUtc(2020, 10, 25, 0, 59, 0);
+  assertEqual(beforePL.getLocalSeconds(), beforeUTC.getLocalSeconds() + 7200);
+  // local time after 1 AM UTC (after 2 AM CEST)
+  LocalDateTime afterUTC = utc.fromUtc(2020, 10, 25, 1, 1, 0);
+  LocalDateTime afterPL = pl.fromUtc(2020, 10, 25, 1, 1, 0);
+  assertEqual(afterPL.getLocalSeconds(), afterUTC.getLocalSeconds() + 3600);
 }
 
 test(local_date_get_time_fragments_at_epoch_start_utc) {


### PR DESCRIPTION
This merge request is to remove epoch seconds from local date time.

Because this was only used in tests and since it is local it doesn't need to know what is the UTC time.