### PR TITLE
Workaround for installation of DS3231 library with version 1.1.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,8 +47,7 @@ jobs:
       - name: Install Libraries Required by Unit Tests
         run: |
           ./arduino-cli lib install "AUnit" "Time" "Timezone"
-          wget https://github.com/NorthernWidget/DS3231/archive/refs/tags/v1.1.1.zip
-          ./arduino-cli lib install --zip-path v1.1.1.zip
+          ./arduino-cli lib install --git-url "https://github.com/NorthernWidget/DS3231.git#v1.1.1"
 
       - name: List top directory
         run: ls -lah
@@ -97,8 +96,7 @@ jobs:
       - name: Install Libraries Required by Sketch
         run: |
           ./arduino-cli lib install "hd44780" "NTPClient" "RotaryEncoder" "Time" "Timezone"
-          wget https://github.com/NorthernWidget/DS3231/archive/refs/tags/v1.1.1.zip
-          ./arduino-cli lib install --zip-path v1.1.1.zip
+          ./arduino-cli lib install --git-url "https://github.com/NorthernWidget/DS3231.git#v1.1.1"
 
       - name: List top directory
         run: ls -lah

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,7 +47,8 @@ jobs:
       - name: Install Libraries Required by Unit Tests
         run: |
           ./arduino-cli lib install "AUnit" "Time" "Timezone"
-          ./arduino-cli lib install --git-url "https://github.com/NorthernWidget/DS3231.git"
+          wget https://github.com/NorthernWidget/DS3231/archive/refs/tags/v1.1.1.zip
+          ./arduino-cli lib install --zip-path v1.1.1.zip
 
       - name: List top directory
         run: ls -lah
@@ -96,7 +97,8 @@ jobs:
       - name: Install Libraries Required by Sketch
         run: |
           ./arduino-cli lib install "hd44780" "NTPClient" "RotaryEncoder" "Time" "Timezone"
-          ./arduino-cli lib install --git-url "https://github.com/NorthernWidget/DS3231.git"
+          wget https://github.com/NorthernWidget/DS3231/archive/refs/tags/v1.1.1.zip
+          ./arduino-cli lib install --zip-path v1.1.1.zip
 
       - name: List top directory
         run: ls -lah

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,7 +45,9 @@ jobs:
           ./arduino-cli config set library.enable_unsafe_install true
 
       - name: Install Libraries Required by Unit Tests
-        run: ./arduino-cli lib install AUnit Time Timezone
+        run: |
+          ./arduino-cli lib install "AUnit" "Time" "Timezone"
+          ./arduino-cli lib install --git-url "https://github.com/NorthernWidget/DS3231.git"
 
       - name: List top directory
         run: ls -lah
@@ -89,6 +91,7 @@ jobs:
           ./arduino-cli config add board_manager.additional_urls https://arduino.esp8266.com/stable/package_esp8266com_index.json
           ./arduino-cli core update-index
           ./arduino-cli core install esp8266:esp8266
+          ./arduino-cli config set library.enable_unsafe_install true
 
       - name: Install Libraries Required by Sketch
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,6 +42,7 @@ jobs:
           ./arduino-cli config add board_manager.additional_urls https://arduino.esp8266.com/stable/package_esp8266com_index.json
           ./arduino-cli core update-index
           ./arduino-cli core install esp8266:esp8266
+          ./arduino-cli config set library.enable_unsafe_install true
 
       - name: Install Libraries Required by Unit Tests
         run: ./arduino-cli lib install AUnit Time Timezone
@@ -90,7 +91,9 @@ jobs:
           ./arduino-cli core install esp8266:esp8266
 
       - name: Install Libraries Required by Sketch
-        run: ./arduino-cli lib install "hd44780" "NTPClient" "RotaryEncoder" "Time" "Timezone" "DS3231"
+        run: |
+          ./arduino-cli lib install "hd44780" "NTPClient" "RotaryEncoder" "Time" "Timezone"
+          ./arduino-cli lib install --git-url "https://github.com/NorthernWidget/DS3231.git"
 
       - name: List top directory
         run: ls -lah

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ We keep [components in src folder](https://forum.arduino.cc/t/how-to-include-fro
 
    ```
    arduino-cli config add board_manager.additional_urls https://arduino.esp8266.com/stable/package_esp8266com_index.json
+   arduino-cli config set library.enable_unsafe_install true
    ```
 
 4. Configure the [autocompletion for command-line](https://arduino.github.io/arduino-cli/0.22/command-line-completion/#generate-the-completion-file) (optional step)
@@ -79,7 +80,8 @@ In root directory:
 1. Install required libraries (i.e. [hd44780](https://github.com/duinoWitchery/hd44780)):
 
    ```bash
-   arduino-cli lib install "hd44780" "NTPClient" "RotaryEncoder" "Time" "Timezone" "DS3231"
+   arduino-cli lib install "hd44780" "NTPClient" "RotaryEncoder" "Time" "Timezone"
+   arduino-cli lib install --git-url "https://github.com/NorthernWidget/DS3231.git"
    ```
 
 2. Compile: `arduino-cli --verbose compile --fqbn esp8266:esp8266:d1`

--- a/README.md
+++ b/README.md
@@ -81,9 +81,8 @@ In root directory:
 
    ```bash
    arduino-cli lib install "hd44780" "NTPClient" "RotaryEncoder" "Time" "Timezone"
-   arduino-cli lib uninstall "DS3231"
-   wget https://github.com/NorthernWidget/DS3231/archive/refs/tags/v1.1.1.zip
-   arduino-cli lib install --zip-path v1.1.1.zip
+   arduino-cli lib uninstall DS3231
+   arduino-cli lib install --git-url "https://github.com/NorthernWidget/DS3231.git#v1.1.1"
    ```
 
 2. Compile: `arduino-cli --verbose compile --fqbn esp8266:esp8266:d1`

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ In root directory:
 
    ```bash
    arduino-cli lib install "hd44780" "NTPClient" "RotaryEncoder" "Time" "Timezone"
-   arduino-cli lib install --git-url "https://github.com/NorthernWidget/DS3231.git"
+   arduino-cli lib uninstall "DS3231"
+   wget https://github.com/NorthernWidget/DS3231/archive/refs/tags/v1.1.1.zip
+   arduino-cli lib install --zip-path v1.1.1.zip
    ```
 
 2. Compile: `arduino-cli --verbose compile --fqbn esp8266:esp8266:d1`


### PR DESCRIPTION
After DS3231 version 1.1.1 is published we can switch to common approach and remove this workaround.

I created the issue for required change:

- https://github.com/NorthernWidget/DS3231/issues/74