### PR TITLE
fix for 'Panic umm_malloc.cpp:229 umm_get_ptr_context'

### DIFF
--- a/crazyclock.ino
+++ b/crazyclock.ino
@@ -121,7 +121,6 @@ void resetToRealTime() {
   FakeTime real = FakeTime(mH, mM, mS);
   real.formatTime(formattedTimeBuffer);
   Serial.println(formattedTimeBuffer);
-  delete &real;
 }
 
 void checkRotaryEncoder() {
@@ -198,7 +197,6 @@ void updateDisplayedTime() {
   FakeTime local = FakeTime(mH, mM, mS);
   local.formatTime(formattedTimeBuffer);
   Serial.println(formattedTimeBuffer);
-  delete &local;
   lcd.setCursor(0, 0);
   lcd.print(formattedTimeBuffer);
 
@@ -208,7 +206,6 @@ void updateDisplayedTime() {
   FakeTime rtc = FakeTime(fromRtc.hour(), fromRtc.minute(), fromRtc.second());
   rtc.formatTime(formattedTimeBuffer);
   Serial.println(formattedTimeBuffer);
-  delete &rtc;
 
   lcd.setCursor(0, 1);
   lcd.print(String("tick:") + String(tick) + String("ms "));

--- a/crazyclock.ino
+++ b/crazyclock.ino
@@ -95,7 +95,7 @@ void loop() {
 
 void resetToRealTime() {
   if (!timeClient.update()) {
-    Serial.print("NTP time update failed");
+    Serial.println("NTP time update failed");
     noWifi = true;
   } else {
     Serial.println("NTP time update successful");


### PR DESCRIPTION
Following error was printed on Serial console when code was deployed to Wemos D1 mini:

```
.....NTP time update successful
19:24:42.716 -> 00:59:41
19:24:42.716 -> 
19:24:42.716 -> User exception (panic/abort/assert)
19:24:42.716 -> --------------- CUT HERE FOR EXCEPTION DECODER ---------------
19:24:42.716 -> 
19:24:42.716 -> Panic umm_malloc.cpp:229 umm_get_ptr_context
19:24:42.716 -> 
19:24:42.716 -> >>>stack>>>
19:24:42.716 -> 
19:24:42.716 -> ctx: cont
19:24:42.716 -> sp: 3ffffea0 end: 3fffffc0 offset: 0000
19:24:42.716 -> 3ffffea0:  3ffe85c8 7fffffff 3ffee984 402051dd  
19:24:42.749 -> 3ffffeb0:  000000fe 00000000 00000000 00000000  
19:24:42.749 -> 3ffffec0:  00000000 00000000 00000000 3ffee980  
19:24:42.749 -> 3ffffed0:  3ffe85d0 00000000 3ffe88f7 3ffee6e4  
19:24:42.749 -> 3ffffee0:  3ffee6f0 00000020 3fffff50 40204caa  
19:24:42.749 -> 3ffffef0:  635de8b0 000007e6 3fffff20 40204d17  
19:24:42.749 -> 3fffff00:  40203b2c 3ffe88f6 3ffee8b0 40100ab8  
19:24:42.749 -> 3fffff10:  40203b2c 3ffe88f6 3ffee8b0 40100bb9  
19:24:42.782 -> 3fffff20:  3ffee6f0 3ffe85c8 3ffee8b0 4020e8a0  
19:24:42.782 -> 3fffff30:  63407cfa 3ffee66c 634060da 4020e874  
19:24:42.782 -> 3fffff40:  3ffee6f0 3ffe85c8 3ffee8b0 402011be  
19:24:42.782 -> 3fffff50:  00000000 0000003b 00000029 63407cfa  
19:24:42.782 -> 3fffff60:  3ffee862 3ffee8b0 3ffee634 3ffe8870  
19:24:42.782 -> 3fffff70:  3ffee862 3ffee8b0 3ffee634 402012b0  
19:24:42.782 -> 3fffff80:  00000018 feefeffe feefeffe feefeffe  
19:24:42.816 -> 3fffff90:  feefeffe feefeffe feefeffe 3ffee93c  
19:24:42.816 -> 3fffffa0:  3fffdad0 00000000 3ffee928 40204838  
19:24:42.816 -> 3fffffb0:  feefeffe feefeffe 3ffe8620 40100f45  
19:24:42.816 -> <<<stack<<<
19:24:42.816 -> 
19:24:42.816 -> --------------- CUT HERE FOR EXCEPTION DECODER ---------------
19:24:42.849 -> 
19:24:42.849 ->  ets Jan  8 2013,rst cause:2, boot mode:(3,7)
19:24:42.849 -> 
19:24:42.849 -> load 0x4010f000, len 3460, room 16 
19:24:42.849 -> tail 4
19:24:42.849 -> chksum 0xcc
19:24:42.849 -> load 0x3fff20b8, len 40, room 4 
19:24:42.849 -> tail 4
19:24:42.849 -> chksum 0xc9
19:24:42.849 -> csum 0xc9
19:24:42.849 -> v00046130
19:24:42.882 -> ~ld
19:24:43.081 -> Looking for the WiFi
19:24:43.581 -> .......NTP time update successful
19:24:47.348 -> 00:59:46
19:24:47.348 -> 
19:24:47.348 -> User exception (panic/abort/assert)
19:24:47.348 -> --------------- CUT HERE FOR EXCEPTION DECODER ---------------
```