### PR TITLE
Add plusMillis function and sample test cases

### DIFF
--- a/src/FakeTime/FakeTime.cpp
+++ b/src/FakeTime/FakeTime.cpp
@@ -22,3 +22,7 @@ int FakeTime::formatTime(char *targetBuffer) {
   sprintf(targetBuffer, "%02d:%02d:%02d", this->_h, this->_m, this->_s);
   return SUCCESS;
 }
+
+void FakeTime::plusMillis(long millis) {
+  // TODO: implement how the time changes when milliseconds are added
+}

--- a/src/FakeTime/FakeTime.h
+++ b/src/FakeTime/FakeTime.h
@@ -16,6 +16,12 @@ public:
   FakeTime(int h, int m, int s);
 
   int formatTime(char *targetBuffer);
+
+  /**
+   * Updates the Fake time so that it show the hour, minute and second
+   * in future (after given milliseconds value).
+   */
+  void plusMillis(long millis);
 };
 
 #endif

--- a/src/FakeTime/FakeTimeTest.ino
+++ b/src/FakeTime/FakeTimeTest.ino
@@ -53,6 +53,58 @@ test(should_handle_seconds_errors_correctly) {
   assertEqual(formattedTimeBuffer, "<initial value>");
 }
 
+test(should_correctly_add_second_and_a_half) {
+  // given
+  char formattedTimeBuffer[20] = "<initial value>";
+  FakeTime tested = FakeTime(0, 1, 2);
+
+  // when
+  tested.plusMillis(1500);
+  tested.formatTime(formattedTimeBuffer);
+
+  // then
+  assertEqual(formattedTimeBuffer, "00:01:03");
+}
+
+test(should_correctly_add_twelve_seconds) {
+  // given
+  char formattedTimeBuffer[20] = "<initial value>";
+  FakeTime tested = FakeTime(17, 00, 00);
+
+  // when
+  tested.plusMillis(12000);
+  tested.formatTime(formattedTimeBuffer);
+
+  // then
+  assertEqual(formattedTimeBuffer, "17:00:12");
+}
+
+test(should_correctly_add_five_minutes_and_33_seconds) {
+  // given
+  char formattedTimeBuffer[20] = "<initial value>";
+  FakeTime tested = FakeTime(17, 00, 00);
+
+  // when
+  tested.plusMillis(333000);
+  tested.formatTime(formattedTimeBuffer);
+
+  // then
+  assertEqual(formattedTimeBuffer, "17:05:33");
+}
+
+test(should_correctly_add_an_hour) {
+  // given
+  char formattedTimeBuffer[20] = "<initial value>";
+  FakeTime tested = FakeTime(17, 00, 00);
+
+  // when
+  tested.plusMillis(3600 * 1000);
+  tested.formatTime(formattedTimeBuffer);
+
+  // then
+  assertEqual(formattedTimeBuffer, "18:00:00");
+}
+
 //----------------------------------------------------------------------------
 // setup() and loop()
 //----------------------------------------------------------------------------


### PR DESCRIPTION
I have prepared some unit tests computing new time based on start time and time passed.

We need to provide implementation for [`plusMillis(long millis)` function](https://github.com/The-Coobaz/crazyclock/pull/44/files#diff-1edf79482afffe24201dbbf9d7e8b9ef92f80f6ca00523ba3866a1c3fcf1446fR26).