### PR TITLE
Some fixes

### DIFF
--- a/crazyclock.ino
+++ b/crazyclock.ino
@@ -17,7 +17,7 @@ LocalDateTimeConverter plDateTimeConverter = LocalDateTimeConverter::PL;
 int mH, mM, mS;  // crazydata
 int tick = 1000; // initial value of tick =1s
 bool change;     // change of time
-bool wifiConnected;
+bool isNtpAvailable;
 char zerro[] = {"0"};
 uint8_t RTChour;
 uint8_t RTCminute;
@@ -66,6 +66,7 @@ void setup() {
     // non zero status means it was unsuccesful
     Serial.println("LCD error status: ");
     Serial.print(status);
+    // begin() failed so blink error code using the onboard LED if possible
     hd44780::fatalError(status); // does not return
   }
 
@@ -79,12 +80,12 @@ void setup() {
     Serial.print(".");
     lcd.print(".");
     if (WiFi.status() == WL_CONNECTED) {
-      wifiConnected = true;
+      isNtpAvailable = true;
       // if wifi found, break loop
       break;
     } else {
       // continue without wifi
-      wifiConnected = false;
+      isNtpAvailable = false;
     };
   }
 
@@ -103,7 +104,7 @@ void loop() {
 void resetToRealTime() {
   if (!timeClient.update()) {
     Serial.println("NTP time update failed");
-    wifiConnected = false;
+    isNtpAvailable = false;
   } else {
     Serial.println("NTP time update successful");
   }
@@ -113,7 +114,7 @@ void resetToRealTime() {
   mM = localDateTime.getLocalTimeFragment(MINUTES);
   mS = localDateTime.getLocalTimeFragment(SECONDS);
 
-  if (wifiConnected) {
+  if (isNtpAvailable) {
     Serial.println("Updating RTC with tim efrom NTP...");
     rtc.setHour(mH);
     rtc.setMinute(mM);

--- a/crazyclock.ino
+++ b/crazyclock.ino
@@ -203,8 +203,8 @@ void updateDisplayedTime() {
   // just to compare real time and the fake one
   Serial.print("RTC Time:");
   DateTime fromRtc = RTClib::now();
-  FakeTime rtc = FakeTime(fromRtc.hour(), fromRtc.minute(), fromRtc.second());
-  rtc.formatTime(formattedTimeBuffer);
+  FakeTime real = FakeTime(fromRtc.hour(), fromRtc.minute(), fromRtc.second());
+  real.formatTime(formattedTimeBuffer);
   Serial.println(formattedTimeBuffer);
 
   lcd.setCursor(0, 1);

--- a/crazyclock.ino
+++ b/crazyclock.ino
@@ -57,6 +57,8 @@ void setup() {
   Serial.println("\n================");
   Serial.println("crazyclock");
   Serial.println("================");
+  Serial.println("Starting I2C...");
+  Wire.begin();
 
   pinMode(RESET_BUTTON_PIN, INPUT);
   int status = lcd.begin(LCD_COLS, LCD_ROWS);

--- a/crazyclock.ino
+++ b/crazyclock.ino
@@ -17,7 +17,7 @@ LocalDateTimeConverter plDateTimeConverter = LocalDateTimeConverter::PL;
 int mH, mM, mS;  // crazydata
 int tick = 1000; // initial value of tick =1s
 bool change;     // change of time
-bool noWifi;
+bool wifiConnected;
 char zerro[] = {"0"};
 uint8_t RTChour;
 uint8_t RTCminute;
@@ -48,36 +48,41 @@ const int LCD_COLS = 16;
 const int LCD_ROWS = 2;
 RotaryEncoder encoder(PIN_IN1, PIN_IN2, RotaryEncoder::LatchMode::TWO03);
 DS3231 rtc;
+
 void setup() {
-  pinMode(RESET_BUTTON_PIN, INPUT);
-  int status;
-  status = lcd.begin(LCD_COLS, LCD_ROWS);
-  if (status) // non zero status means it was unsuccesful
-  {
-    // begin() failed so blink error code using the onboard LED if possible
-    hd44780::fatalError(status); // does not return
-  }
-  lcd.print("Waiting for WiFi");
-  lcd.setCursor(0, 1);
   Serial.begin(115200);
   while (!Serial) {
     // waits for serial port to be ready
   }
+  Serial.println("\n================");
+  Serial.println("crazyclock");
+  Serial.println("================");
 
+  pinMode(RESET_BUTTON_PIN, INPUT);
+  int status = lcd.begin(LCD_COLS, LCD_ROWS);
+  if (status) {
+    // non zero status means it was unsuccesful
+    Serial.println("LCD error status: ");
+    Serial.print(status);
+    hd44780::fatalError(status); // does not return
+  }
+
+  Serial.println("Waiting for WiFi");
+  lcd.print("Waiting for WiFi");
+  lcd.setCursor(0, 1);
   WiFi.begin(ssid, password);
-  Serial.println("Looking for the WiFi");
   // wait for 15 seconds to find wifi, then start without it
   for (int n = 0; n < 30; n++) {
     delay(500);
     Serial.print(".");
     lcd.print(".");
     if (WiFi.status() == WL_CONNECTED) {
-      noWifi = false;
+      wifiConnected = true;
       // if wifi found, break loop
       break;
     } else {
       // continue without wifi
-      noWifi = true;
+      wifiConnected = false;
     };
   }
 
@@ -96,7 +101,7 @@ void loop() {
 void resetToRealTime() {
   if (!timeClient.update()) {
     Serial.println("NTP time update failed");
-    noWifi = true;
+    wifiConnected = false;
   } else {
     Serial.println("NTP time update successful");
   }
@@ -106,11 +111,13 @@ void resetToRealTime() {
   mM = localDateTime.getLocalTimeFragment(MINUTES);
   mS = localDateTime.getLocalTimeFragment(SECONDS);
 
-  if (noWifi = false) {
+  if (wifiConnected) {
+    Serial.println("Updating RTC with tim efrom NTP...");
     rtc.setHour(mH);
     rtc.setMinute(mM);
     rtc.setSecond(mS);
   } else {
+    Serial.println("NTP is not available. Getting the time from RTC...");
     DateTime fromRtc = RTClib::now();
     mH = fromRtc.hour();
     mM = fromRtc.minute();
@@ -120,6 +127,7 @@ void resetToRealTime() {
   change = false;
   FakeTime real = FakeTime(mH, mM, mS);
   real.formatTime(formattedTimeBuffer);
+  Serial.print("Resetting to real time: ");
   Serial.println(formattedTimeBuffer);
 }
 


### PR DESCRIPTION
I had some troubles when two of I2C devices were connected.

The LCD screen was not working and kept reporting [error status `-4`](https://github.com/duinoWitchery/hd44780/blob/master/hd44780.h#L110).

I needed to add the `Wire.begin()` line. I also fixed the variable name overwrite (`rtc`) and renamed the variable for WIFI status.