### PR TITLE
Remove not needed lines

### DIFF
--- a/crazyclock.ino
+++ b/crazyclock.ino
@@ -52,8 +52,6 @@ void setup() {
     // waits for serial port to be ready
   }
   Serial.println("\n================\ncrazyclock\n================");
-  Serial.println("Starting I2C...");
-  Wire.begin();
 
   pinMode(RESET_BUTTON_PIN, INPUT);
   int status = lcd.begin(LCD_COLS, LCD_ROWS);


### PR DESCRIPTION
`Wire.begin()` [is required for I2C protocol](https://www.arduino.cc/reference/en/language/functions/communication/wire/begin/).

But it should be called only once. Maybe because of that I had some troubles on Wemos D1 mini.
Because it is also called internally by LCD library:

- https://github.com/duinoWitchery/hd44780/blob/1.3.2/hd44780ioClass/hd44780_I2Cexp.h#L367

I remove it, afer we confirmed with @Qbunjo that it also works correctly without those lines on ESP8266.
