### PR TITLE
Fix for memory leaks

### DIFF
--- a/crazyclock.ino
+++ b/crazyclock.ino
@@ -21,7 +21,7 @@ bool change;     // change of time
 bool isNtpAvailable;
 
 char formattedTimeBuffer[20] = "<initial value>";
-FakeTime timeFromRTC;
+FakeTime fakeTimeFromRTC;
 FakeTime fakeTime;
 
 #if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO_EVERY)
@@ -48,7 +48,7 @@ const int LCD_COLS = 16;
 const int LCD_ROWS = 2;
 RotaryEncoder encoder(PIN_IN1, PIN_IN2, RotaryEncoder::LatchMode::TWO03);
 DS3231 rtc;
-DateTime rtcNow;
+DateTime fromRtc;
 
 void setup() {
   pinMode(RESET_BUTTON_PIN, INPUT);
@@ -103,14 +103,14 @@ bool retrieveEpochTimeFromNTP(hd44780_I2Cexp lcd, unsigned long *epochSeconds) {
 }
 
 void resetToRealTime() {
-  rtcNow = RTClib::now();
-  mH = rtcNow.hour();
-  mM = rtcNow.minute();
-  mS = rtcNow.second();
+  fromRtc = RTClib::now();
+  mH = fromRtc.hour();
+  mM = fromRtc.minute();
+  mS = fromRtc.second();
   tick = 1000;
   change = false;
-  timeFromRTC.setTime(mH, mM, mS);
-  timeFromRTC.formatTime(formattedTimeBuffer);
+  fakeTimeFromRTC.setTime(mH, mM, mS);
+  fakeTimeFromRTC.formatTime(formattedTimeBuffer);
   Serial.print("Resetting to real time: ");
   Serial.println(formattedTimeBuffer);
 }
@@ -152,10 +152,10 @@ void ticTac() {
   }
   if (!change) {
     // if time is not changed, synchronize with RTC  every second
-    rtcNow = RTClib::now();
-    mH = rtcNow.hour();
-    mM = rtcNow.minute();
-    mS = rtcNow.second();
+    fromRtc = RTClib::now();
+    mH = fromRtc.hour();
+    mM = fromRtc.minute();
+    mS = fromRtc.second();
   };
   if (mS == 60 and tick > 0) {
     mS = 0;
@@ -194,9 +194,9 @@ void updateDisplayedTime() {
 
   // just to compare real time and the fake one
   Serial.print("RTC Time:");
-  rtcNow = RTClib::now();
-  timeFromRTC.setTime(rtcNow.hour(), rtcNow.minute(), rtcNow.second());
-  timeFromRTC.formatTime(formattedTimeBuffer);
+  fromRtc = RTClib::now();
+  fakeTimeFromRTC.setTime(fromRtc.hour(), fromRtc.minute(), fromRtc.second());
+  fakeTimeFromRTC.formatTime(formattedTimeBuffer);
   Serial.println(formattedTimeBuffer);
 
   lcd.setCursor(0, 1);

--- a/crazyclock.ino
+++ b/crazyclock.ino
@@ -48,8 +48,8 @@ const int LCD_COLS = 16;
 const int LCD_ROWS = 2;
 RotaryEncoder encoder(PIN_IN1, PIN_IN2, RotaryEncoder::LatchMode::TWO03);
 DS3231 rtc;
-bool is12HFormat;
-bool isPMTime;
+bool is12h;
+bool isPM;
 
 void setup() {
   pinMode(RESET_BUTTON_PIN, INPUT);
@@ -104,7 +104,7 @@ bool retrieveEpochTimeFromNTP(hd44780_I2Cexp lcd, unsigned long *epochSeconds) {
 }
 
 void resetToRealTime() {
-  mH = rtc.getHour(is12HFormat, isPMTime);
+  mH = rtc.getHour(is12h, isPM);
   mM = rtc.getMinute();
   mS = rtc.getSecond();
   tick = 1000;
@@ -152,7 +152,7 @@ void ticTac() {
   }
   if (!change) {
     // if time is not changed, synchronize with RTC  every second
-    mH = rtc.getHour(is12HFormat, isPMTime);
+    mH = rtc.getHour(is12h, isPM);
     mM = rtc.getMinute();
     mS = rtc.getSecond();
   };
@@ -193,7 +193,8 @@ void updateDisplayedTime() {
 
   // just to compare real time and the fake one
   Serial.print("RTC Time:");
-  fakeTimeFromRTC.setTime(rtc.getHour(is12HFormat, isPMTime), rtc.getMinute(), rtc.getSecond());
+  fakeTimeFromRTC.setTime(rtc.getHour(is12h, isPM), rtc.getMinute(),
+                          rtc.getSecond());
   fakeTimeFromRTC.formatTime(formattedTimeBuffer);
   Serial.println(formattedTimeBuffer);
 

--- a/crazyclock.ino
+++ b/crazyclock.ino
@@ -104,10 +104,12 @@ void resetToRealTime() {
   mH = fromRtc.hour();
   mM = fromRtc.minute();
   mS = fromRtc.second();
+  delete &fromRtc;
   tick = 1000;
   change = false;
   FakeTime real = FakeTime(mH, mM, mS);
   real.formatTime(formattedTimeBuffer);
+  delete &real;
   Serial.print("Resetting to real time: ");
   Serial.println(formattedTimeBuffer);
 }
@@ -153,6 +155,7 @@ void ticTac() {
     mH = fromRtc.hour();
     mM = fromRtc.minute();
     mS = fromRtc.second();
+    delete &fromRtc;
   };
   if (mS == 60 and tick > 0) {
     mS = 0;
@@ -185,6 +188,7 @@ void updateDisplayedTime() {
   Serial.print("Local time:");
   FakeTime local = FakeTime(mH, mM, mS);
   local.formatTime(formattedTimeBuffer);
+  delete &local;
   Serial.println(formattedTimeBuffer);
   lcd.setCursor(0, 0);
   lcd.print(formattedTimeBuffer);
@@ -193,7 +197,9 @@ void updateDisplayedTime() {
   Serial.print("RTC Time:");
   DateTime fromRtc = RTClib::now();
   FakeTime real = FakeTime(fromRtc.hour(), fromRtc.minute(), fromRtc.second());
+  delete &fromRtc;
   real.formatTime(formattedTimeBuffer);
+  delete &real;
   Serial.println(formattedTimeBuffer);
 
   lcd.setCursor(0, 1);

--- a/crazyclock.ino
+++ b/crazyclock.ino
@@ -48,7 +48,8 @@ const int LCD_COLS = 16;
 const int LCD_ROWS = 2;
 RotaryEncoder encoder(PIN_IN1, PIN_IN2, RotaryEncoder::LatchMode::TWO03);
 DS3231 rtc;
-DateTime fromRtc;
+bool is12HFormat;
+bool isPMTime;
 
 void setup() {
   pinMode(RESET_BUTTON_PIN, INPUT);
@@ -103,10 +104,9 @@ bool retrieveEpochTimeFromNTP(hd44780_I2Cexp lcd, unsigned long *epochSeconds) {
 }
 
 void resetToRealTime() {
-  fromRtc = RTClib::now();
-  mH = fromRtc.hour();
-  mM = fromRtc.minute();
-  mS = fromRtc.second();
+  mH = rtc.getHour(is12HFormat, isPMTime);
+  mM = rtc.getMinute();
+  mS = rtc.getSecond();
   tick = 1000;
   change = false;
   fakeTimeFromRTC.setTime(mH, mM, mS);
@@ -152,10 +152,9 @@ void ticTac() {
   }
   if (!change) {
     // if time is not changed, synchronize with RTC  every second
-    fromRtc = RTClib::now();
-    mH = fromRtc.hour();
-    mM = fromRtc.minute();
-    mS = fromRtc.second();
+    mH = rtc.getHour(is12HFormat, isPMTime);
+    mM = rtc.getMinute();
+    mS = rtc.getSecond();
   };
   if (mS == 60 and tick > 0) {
     mS = 0;
@@ -194,8 +193,7 @@ void updateDisplayedTime() {
 
   // just to compare real time and the fake one
   Serial.print("RTC Time:");
-  fromRtc = RTClib::now();
-  fakeTimeFromRTC.setTime(fromRtc.hour(), fromRtc.minute(), fromRtc.second());
+  fakeTimeFromRTC.setTime(rtc.getHour(is12HFormat, isPMTime), rtc.getMinute(), rtc.getSecond());
   fakeTimeFromRTC.formatTime(formattedTimeBuffer);
   Serial.println(formattedTimeBuffer);
 

--- a/src/FakeTime/FakeTime.cpp
+++ b/src/FakeTime/FakeTime.cpp
@@ -2,10 +2,10 @@
 #include "FakeTime.h"
 #include <stdio.h>
 
-FakeTime::FakeTime(int h, int m, int s) {
-  this->_h = h;
-  this->_m = m;
-  this->_s = s;
+FakeTime::FakeTime() {
+  this->_h = 0;
+  this->_m = 0;
+  this->_s = 0;
 }
 
 int FakeTime::setTime(int h, int m, int s) {

--- a/src/FakeTime/FakeTime.cpp
+++ b/src/FakeTime/FakeTime.cpp
@@ -24,17 +24,6 @@ int FakeTime::setTime(int h, int m, int s) {
   return SUCCESS;
 }
 
-int FakeTime::formatTime(char *targetBuffer) {
-  if (this->_h < 0 || this->_h > 23) {
-    return INCORRECT_HOUR;
-  }
-  if (this->_m < 0 || this->_m > 59) {
-    return INCORRECT_MINUTE;
-  }
-  if (this->_s < 0 || this->_s > 59) {
-    return INCORRECT_SECOND;
-  }
-
+void FakeTime::formatTime(char *targetBuffer) {
   sprintf(targetBuffer, "%02d:%02d:%02d", this->_h, this->_m, this->_s);
-  return SUCCESS;
 }

--- a/src/FakeTime/FakeTime.cpp
+++ b/src/FakeTime/FakeTime.cpp
@@ -8,6 +8,22 @@ FakeTime::FakeTime(int h, int m, int s) {
   this->_s = s;
 }
 
+int FakeTime::setTime(int h, int m, int s) {
+  if (h < 0 || h > 23) {
+    return INCORRECT_HOUR;
+  }
+  if (m < 0 || m > 59) {
+    return INCORRECT_MINUTE;
+  }
+  if (s < 0 || s > 59) {
+    return INCORRECT_SECOND;
+  }
+  this->_h = h;
+  this->_m = m;
+  this->_s = s;
+  return SUCCESS;
+}
+
 int FakeTime::formatTime(char *targetBuffer) {
   if (this->_h < 0 || this->_h > 23) {
     return INCORRECT_HOUR;

--- a/src/FakeTime/FakeTime.h
+++ b/src/FakeTime/FakeTime.h
@@ -16,7 +16,7 @@ public:
   FakeTime();
 
   int setTime(int h, int m, int s);
-  int formatTime(char *targetBuffer);
+  void formatTime(char *targetBuffer);
 };
 
 #endif

--- a/src/FakeTime/FakeTime.h
+++ b/src/FakeTime/FakeTime.h
@@ -15,6 +15,7 @@ private:
 public:
   FakeTime(int h, int m, int s);
 
+  int setTime(int h, int m, int s);
   int formatTime(char *targetBuffer);
 };
 

--- a/src/FakeTime/FakeTime.h
+++ b/src/FakeTime/FakeTime.h
@@ -13,7 +13,7 @@ private:
   int _s;
 
 public:
-  FakeTime(int h, int m, int s);
+  FakeTime();
 
   int setTime(int h, int m, int s);
   int formatTime(char *targetBuffer);

--- a/src/FakeTime/FakeTimeTest.ino
+++ b/src/FakeTime/FakeTimeTest.ino
@@ -53,6 +53,54 @@ test(should_handle_seconds_errors_correctly) {
   assertEqual(formattedTimeBuffer, "<initial value>");
 }
 
+test(should_update_valid_times) {
+  char formattedTimeBuffer[20] = "<initial value>";
+  FakeTime tested = FakeTime(0, 0, 0);
+
+  tested.setTime(12, 34, 56);
+  tested.formatTime(formattedTimeBuffer);
+  assertEqual(formattedTimeBuffer, "12:34:56");
+
+  tested.setTime(0, 0, 0);
+  tested.formatTime(formattedTimeBuffer);
+  assertEqual(formattedTimeBuffer, "00:00:00");
+
+  tested.setTime(0, 6, 30);
+  tested.formatTime(formattedTimeBuffer);
+  assertEqual(formattedTimeBuffer, "00:06:30");
+
+  tested.setTime(0, 0, 1);
+  tested.formatTime(formattedTimeBuffer);
+  assertEqual(formattedTimeBuffer, "00:00:01");
+}
+
+test(should_handle_hours_errors_correctly_for_updates) {
+
+  int status = SUCCESS;
+  FakeTime tested = FakeTime(0, 0, 0);
+
+  status = tested.setTime(-1, 34, 56);
+  assertEqual(status, INCORRECT_HOUR);
+}
+
+test(should_handle_minutes_errors_correctly_for_updates) {
+
+  int status = SUCCESS;
+  FakeTime tested = FakeTime(0, 0, 0);
+
+  status = tested.setTime(0, 60, 0);
+  assertEqual(status, INCORRECT_MINUTE);
+}
+
+test(should_handle_seconds_errors_correctly_for_updates) {
+
+  int status = SUCCESS;
+  FakeTime tested = FakeTime(0, 0, 0);
+
+  status = tested.setTime(6, 5, 65);
+  assertEqual(status, INCORRECT_SECOND);
+}
+
 //----------------------------------------------------------------------------
 // setup() and loop()
 //----------------------------------------------------------------------------

--- a/src/FakeTime/FakeTimeTest.ino
+++ b/src/FakeTime/FakeTimeTest.ino
@@ -3,56 +3,6 @@
 
 #include "FakeTime.h"
 
-test(should_format_valid_times) {
-
-  char formattedTimeBuffer[20] = "<initial value>";
-  int status = FakeTime(12, 34, 56).formatTime(formattedTimeBuffer);
-  assertEqual(status, SUCCESS);
-  assertEqual(formattedTimeBuffer, "12:34:56");
-
-  status = FakeTime(0, 0, 0).formatTime(formattedTimeBuffer);
-  assertEqual(status, SUCCESS);
-  assertEqual(formattedTimeBuffer, "00:00:00");
-
-  status = FakeTime(6, 30, 0).formatTime(formattedTimeBuffer);
-  assertEqual(status, SUCCESS);
-  assertEqual(formattedTimeBuffer, "06:30:00");
-
-  status = FakeTime(0, 0, 1).formatTime(formattedTimeBuffer);
-  assertEqual(status, SUCCESS);
-  assertEqual(formattedTimeBuffer, "00:00:01");
-}
-
-test(should_handle_hours_errors_correctly) {
-
-  int status = SUCCESS;
-  char formattedTimeBuffer[20] = "<initial value>";
-
-  status = FakeTime(-1, 34, 56).formatTime(formattedTimeBuffer);
-  assertEqual(status, INCORRECT_HOUR);
-  assertEqual(formattedTimeBuffer, "<initial value>");
-}
-
-test(should_handle_minutes_errors_correctly) {
-
-  int status = SUCCESS;
-  char formattedTimeBuffer[20] = "<initial value>";
-
-  status = FakeTime(0, 60, 0).formatTime(formattedTimeBuffer);
-  assertEqual(status, INCORRECT_MINUTE);
-  assertEqual(formattedTimeBuffer, "<initial value>");
-}
-
-test(should_handle_seconds_errors_correctly) {
-
-  int status = SUCCESS;
-  char formattedTimeBuffer[20] = "<initial value>";
-
-  status = FakeTime(6, 5, 65).formatTime(formattedTimeBuffer);
-  assertEqual(status, INCORRECT_SECOND);
-  assertEqual(formattedTimeBuffer, "<initial value>");
-}
-
 test(should_update_valid_times) {
   char formattedTimeBuffer[20] = "<initial value>";
   FakeTime tested = FakeTime(0, 0, 0);

--- a/src/FakeTime/FakeTimeTest.ino
+++ b/src/FakeTime/FakeTimeTest.ino
@@ -5,7 +5,7 @@
 
 test(should_update_valid_times) {
   char formattedTimeBuffer[20] = "<initial value>";
-  FakeTime tested = FakeTime(0, 0, 0);
+  FakeTime tested = FakeTime();
 
   tested.setTime(12, 34, 56);
   tested.formatTime(formattedTimeBuffer);
@@ -27,7 +27,7 @@ test(should_update_valid_times) {
 test(should_handle_hours_errors_correctly_for_updates) {
 
   int status = SUCCESS;
-  FakeTime tested = FakeTime(0, 0, 0);
+  FakeTime tested = FakeTime();
 
   status = tested.setTime(-1, 34, 56);
   assertEqual(status, INCORRECT_HOUR);
@@ -36,7 +36,7 @@ test(should_handle_hours_errors_correctly_for_updates) {
 test(should_handle_minutes_errors_correctly_for_updates) {
 
   int status = SUCCESS;
-  FakeTime tested = FakeTime(0, 0, 0);
+  FakeTime tested = FakeTime();
 
   status = tested.setTime(0, 60, 0);
   assertEqual(status, INCORRECT_MINUTE);
@@ -45,7 +45,7 @@ test(should_handle_minutes_errors_correctly_for_updates) {
 test(should_handle_seconds_errors_correctly_for_updates) {
 
   int status = SUCCESS;
-  FakeTime tested = FakeTime(0, 0, 0);
+  FakeTime tested = FakeTime();
 
   status = tested.setTime(6, 5, 65);
   assertEqual(status, INCORRECT_SECOND);

--- a/src/FakeTime/FakeTimeTest.ino
+++ b/src/FakeTime/FakeTimeTest.ino
@@ -15,9 +15,9 @@ test(should_update_valid_times) {
   tested.formatTime(formattedTimeBuffer);
   assertEqual(formattedTimeBuffer, "00:00:00");
 
-  tested.setTime(0, 6, 30);
+  tested.setTime(6, 30, 0);
   tested.formatTime(formattedTimeBuffer);
-  assertEqual(formattedTimeBuffer, "00:06:30");
+  assertEqual(formattedTimeBuffer, "06:30:00");
 
   tested.setTime(0, 0, 1);
   tested.formatTime(formattedTimeBuffer);


### PR DESCRIPTION
Memory leaks (creation of `FakeTime` class instances in `updateDisplayedTime()` function was a reason for which the LCD stopped being updated.

This pull request introduces changes for class instances to be generated once.

See also:

- https://stackoverflow.com/questions/1880984/when-are-variables-removed-from-memory-in-c