### PR TITLE
fine-grained tick adjustment

### DIFF
--- a/crazyclock.ino
+++ b/crazyclock.ino
@@ -120,9 +120,9 @@ void checkRotaryEncoder() {
   if (pos != newPos) {
     change = true;
     if (newPos > pos) {
-      tick = tick + 50;
+      tick = tick + 10;
     } else {
-      tick = tick - 50;
+      tick = tick - 10;
     }
 
     pos = newPos;


### PR DESCRIPTION
This merge request is to allow very small tick time (10 ms).

By setting it to such small values it should be easier to observe memory leaks (if there are any).

After 8 minutes of running with tick = 10ms my LCD started to show *real* time flow: seconds were updated every 1000ms instead of every 10ms. @Qbunjo , can you check that on your hardware? To confirm that we indeed have some issues before we fix them in https://github.com/The-Coobaz/crazyclock/pull/51