### PR TITLE
Remove env variable

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,8 +6,6 @@ on:
 env:
   # https://arduino.github.io/arduino-cli/latest/installation/#download
   ARDUINO_CLI_FILE: arduino-cli_latest_Linux_64bit.tar.gz
-  # for https://github.com/bxparks/EpoxyDuino#additional-arduino-library-locations
-  ARDUINO_CLI_DIR: ${HOME}/Arduino
 
 jobs:
   # https://github.com/marketplace/actions/clang-format-check#single-path

--- a/README.md
+++ b/README.md
@@ -98,8 +98,4 @@ In root directory:
 
 1. AUnit library: `arduino-cli lib install AUnit`
 2. [EpoxyDuino](https://github.com/bxparks/EpoxyDuino#installation) v1.5.0 in crazyclock `libraries` folder
-3. Set environment variable `ARDUINO_CLI_DIR` for `arduino-cli` libraries:
-   ```bash
-   export ARDUINO_CLI_DIR=${HOME}/Arduino
-   ```
-4. Inside `src` folder run command `make`
+3. Inside `src` folder run command `make`

--- a/src/LocalDateTimeConverter/Makefile
+++ b/src/LocalDateTimeConverter/Makefile
@@ -3,5 +3,5 @@
 
 APP_NAME := LocalDateTimeConverterTest
 ARDUINO_LIBS := AUnit Timezone Time
-ARDUINO_LIB_DIRS := ${ARDUINO_CLI_DIR}/libraries
+ARDUINO_LIB_DIRS := ${HOME}/Arduino/libraries
 include ../../libraries/EpoxyDuino/EpoxyDuino.mk

--- a/src/computeFakeTime/Makefile
+++ b/src/computeFakeTime/Makefile
@@ -3,5 +3,5 @@
 
 APP_NAME := computeFakeTimeTest
 ARDUINO_LIBS := AUnit
-ARDUINO_LIB_DIRS := ${ARDUINO_CLI_DIR}/libraries
+ARDUINO_LIB_DIRS := ${HOME}/Arduino/libraries
 include ../../libraries/EpoxyDuino/EpoxyDuino.mk


### PR DESCRIPTION
We can use provided environment variable `$HOME`, because Arduino libraries are always installed in the same folder.