### PR TITLE
Remove not needed code from local datetime converter

### DIFF
--- a/src/LocalDateTimeConverter/LocalDateTimeConverter.cpp
+++ b/src/LocalDateTimeConverter/LocalDateTimeConverter.cpp
@@ -15,22 +15,6 @@ Timezone pl(dstRule, stdRule);
 
 LocalDateTimeConverter::LocalDateTimeConverter(int tzId) { timezoneId = tzId; }
 
-LocalDateTime LocalDateTimeConverter::fromUtc(int year, int month, int day,
-                                              int hour, int minute,
-                                              int second) {
-  TimeElements timeElements;
-  timeElements.Year = year - 1970;
-  timeElements.Month = month;
-  timeElements.Day = day;
-  timeElements.Hour = hour;
-  timeElements.Minute = minute;
-  timeElements.Second = second;
-
-  unsigned long seconds = makeTime(timeElements);
-
-  return this->fromUtc(seconds);
-}
-
 LocalDateTime LocalDateTimeConverter::fromUtc(unsigned long epochSeconds) {
   return LocalDateTime(this->toLocalSeconds(epochSeconds));
 }

--- a/src/LocalDateTimeConverter/LocalDateTimeConverter.h
+++ b/src/LocalDateTimeConverter/LocalDateTimeConverter.h
@@ -18,8 +18,6 @@ public:
   static LocalDateTimeConverter UTC;
   static LocalDateTimeConverter PL;
 
-  LocalDateTime fromUtc(int year, int month, int day, int hour, int minute,
-                        int second);
   LocalDateTime fromUtc(unsigned long epochSeconds);
 };
 

--- a/src/LocalDateTimeConverter/LocalDateTimeConverterTest.ino
+++ b/src/LocalDateTimeConverter/LocalDateTimeConverterTest.ino
@@ -4,7 +4,7 @@
 #include "LocalDateTimeConverter.h"
 
 // UTC seconds for 2022-02-14T12:34:56UTC
-unsigned long valentinesUTCSecond = 1644842096ul;
+unsigned long valentinesUTCSecond = 1644842096;
 
 test(should_be_one_hour_later_in_PL_at_epoch_start) {
   // given
@@ -65,10 +65,10 @@ test(should_convert_PL_time_near_spring_time_change) {
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
 
   // 2020-01-29, 00:59:00 UTC
-  unsigned long utcBefore = 1580259540ul;
+  unsigned long utcBefore = 1580259540;
   LocalDateTime beforePL = pl.fromUtc(utcBefore);
   // 2020-01-29, 01:01:00 UTC
-  unsigned long utcAfter = 1580259660ul;
+  unsigned long utcAfter = 1580259660;
   LocalDateTime afterPL = pl.fromUtc(utcAfter);
 
   assertEqual(beforePL.getLocalSeconds(), utcBefore + 3600);
@@ -81,10 +81,10 @@ test(should_convert_PL_time_near_autumn_time_change) {
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
 
   // 2020-10-25, 00:59:00 UTC
-  unsigned long utcBefore = 1603587540ul;
+  unsigned long utcBefore = 1603587540;
   LocalDateTime beforePL = pl.fromUtc(utcBefore);
   // 2020-10-25, 02:01:00 UTC
-  unsigned long utcAfter = 1603587660ul;
+  unsigned long utcAfter = 1603587660;
   LocalDateTime afterPL = pl.fromUtc(utcAfter);
 
   assertEqual(beforePL.getLocalSeconds(), utcBefore + 7200);

--- a/src/LocalDateTimeConverter/LocalDateTimeConverterTest.ino
+++ b/src/LocalDateTimeConverter/LocalDateTimeConverterTest.ino
@@ -92,8 +92,25 @@ test(should_convert_PL_time_near_autumn_time_change) {
 }
 
 // in October we change the clock from 3 AM to 2 AM
-test(
-    should_convert_to_PL_time_and_return_time_fragments_near_autumn_time_change_2022) {
+test(should_convert_to_same_PL_time_twice_during_a_night) {
+  // given
+  LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
+
+  // 2020-10-25, 00:00:30 UTC
+  unsigned long utcFirst = 1603585800;
+  LocalDateTime firstPL = pl.fromUtc(utcFirst);
+  // 2020-10-25, 00:01:30 UTC
+  unsigned long utcSecond = 1603589400;
+  LocalDateTime secondPL = pl.fromUtc(utcSecond);
+
+  // 2020-10-25, 00:02:30
+  unsigned long expected = 1603593000;
+  assertEqual(firstPL.getLocalSeconds(), expected);
+  assertEqual(secondPL.getLocalSeconds(), expected);
+}
+
+// in October we change the clock from 3 AM to 2 AM
+test(should_convert_with_time_fragments_near_autumn_time_change_2022) {
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
 
   // 2022-10-30, 00:00:00 UTC

--- a/src/LocalDateTimeConverter/LocalDateTimeConverterTest.ino
+++ b/src/LocalDateTimeConverter/LocalDateTimeConverterTest.ino
@@ -18,7 +18,7 @@ test(should_be_one_hour_later_in_PL_at_epoch_start) {
   assertEqual(localDateTime.getLocalSeconds(), epochStart + 3600);
 }
 
-test(should_recognize_same_time_on_valentines_day) {
+test(should_recognize_valentines_day_in_UTC_and_PL) {
   // given
   LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
@@ -64,11 +64,11 @@ test(should_convert_PL_time_near_spring_time_change) {
   // given
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
 
-  // 2020-01-29, 00:59:00 UTC
-  unsigned long utcBefore = 1580259540;
+  // 2020-03-29, 00:59:59 UTC
+  unsigned long utcBefore = 1585443599;
   LocalDateTime beforePL = pl.fromUtc(utcBefore);
-  // 2020-01-29, 01:01:00 UTC
-  unsigned long utcAfter = 1580259660;
+  // 2020-03-29, 01:00:00 UTC
+  unsigned long utcAfter = 1585443600;
   LocalDateTime afterPL = pl.fromUtc(utcAfter);
 
   assertEqual(beforePL.getLocalSeconds(), utcBefore + 3600);
@@ -80,11 +80,11 @@ test(should_convert_PL_time_near_autumn_time_change) {
   // given
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
 
-  // 2020-10-25, 00:59:00 UTC
-  unsigned long utcBefore = 1603587540;
+  // 2020-10-25, 00:59:59 UTC
+  unsigned long utcBefore = 1603587599;
   LocalDateTime beforePL = pl.fromUtc(utcBefore);
-  // 2020-10-25, 02:01:00 UTC
-  unsigned long utcAfter = 1603587660;
+  // 2020-10-25, 01:00:00 UTC
+  unsigned long utcAfter = 1603587600;
   LocalDateTime afterPL = pl.fromUtc(utcAfter);
 
   assertEqual(beforePL.getLocalSeconds(), utcBefore + 7200);

--- a/src/LocalDateTimeConverter/LocalDateTimeConverterTest.ino
+++ b/src/LocalDateTimeConverter/LocalDateTimeConverterTest.ino
@@ -6,7 +6,7 @@
 // UTC seconds for 2022-02-14T12:34:56UTC
 unsigned long valentinesUTCSecond = 1644842096ul;
 
-test(epoch_start_test) {
+test(should_be_one_hour_later_in_PL_at_epoch_start) {
   // given
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
   unsigned long epochStart = 0;
@@ -18,122 +18,89 @@ test(epoch_start_test) {
   assertEqual(localDateTime.getLocalSeconds(), epochStart + 3600);
 }
 
-test(valentines_day) {
+test(should_recognize_same_time_on_valentines_day) {
   // given
   LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
-  LocalDateTime valentinesInUTC = utc.fromUtc(2022, 2, 14, 12, 34, 56);
-  LocalDateTime valentinesInPL = pl.fromUtc(2022, 2, 14, 12, 34, 56);
+  LocalDateTime valentinesInUTC = utc.fromUtc(valentinesUTCSecond);
+  LocalDateTime valentinesInPL = pl.fromUtc(valentinesUTCSecond);
 
   // then
   assertEqual(valentinesInUTC.getLocalSeconds(), valentinesUTCSecond);
   assertEqual(valentinesInPL.getLocalSeconds(), valentinesUTCSecond + 3600);
 }
 
-test(utc_conversion_to_seconds) {
+test(should_correctly_show_UTC_time) {
   LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
 
-  assertEqual(utc.fromUtc(2022, 2, 14, 12, 34, 56).getLocalSeconds(),
-              valentinesUTCSecond);
-  assertEqual(utc.fromUtc(2020, 2, 29, 0, 0, 0).getLocalSeconds(),
-              1582934400ul);
-  assertEqual(utc.fromUtc(2050, 8, 15, 17, 15, 0).getLocalSeconds(),
-              2544196500ul);
-  assertEqual(utc.fromUtc(2100, 8, 15, 17, 15, 0).getLocalSeconds(),
-              4122033300ul);
+  // epoch start
+  assertEqual(utc.fromUtc(0ul).getLocalSeconds(), 0ul);
+  // 2020-02-29, 00:00:00 UTC
+  assertEqual(utc.fromUtc(1582934400ul).getLocalSeconds(), 1582934400ul);
+  // 2050-08-15, 17:15:00 UTC
+  assertEqual(utc.fromUtc(2544196500ul).getLocalSeconds(), 2544196500ul);
+  // 2100-08-15, 17:15:00 UTC
+  assertEqual(utc.fromUtc(4122033300ul).getLocalSeconds(), 4122033300ul);
 
-  // 15th of August 2200
-  // number overflow?
-  // assertEqual(utc.fromUtc(2200, 8, 15, 17, 15, 0), 7277706900ul);
+  // 15th of August 2200 -> number overflow?
+  // assertEqual(utc.fromUtc(7277706900ul), 7277706900ul);
 }
 
-test(pl_conversion_to_seconds) {
+test(should_correctly_convert_to_PL_time) {
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
 
   // epoch start
   assertEqual(pl.fromUtc(0ul).getLocalSeconds(), 3600ul);
-
-  assertEqual(pl.fromUtc(2022, 2, 14, 12, 34, 56).getLocalSeconds(),
-              valentinesUTCSecond + 3600);
-  assertEqual(pl.fromUtc(2020, 2, 29, 0, 0, 0).getLocalSeconds(),
-              1582934400ul + 3600);
-  assertEqual(pl.fromUtc(2050, 8, 15, 17, 15, 0).getLocalSeconds(),
-              2544196500ul + 7200);
-  assertEqual(pl.fromUtc(2100, 8, 15, 17, 15, 0).getLocalSeconds(),
-              4122033300ul + 7200);
+  // 2020-02-29, 00:00:00 UTC
+  assertEqual(pl.fromUtc(1582934400ul).getLocalSeconds(), 1582934400ul + 3600);
+  // 2050-08-15, 17:15:00 UTC
+  assertEqual(pl.fromUtc(2544196500ul).getLocalSeconds(), 2544196500ul + 7200);
+  // 2100-08-15, 17:15:00 UTC
+  assertEqual(pl.fromUtc(4122033300ul).getLocalSeconds(), 4122033300ul + 7200);
 }
 
 // in March we change the clock from 2 AM to 3 AM
-test(pl_conversion_near_spring_time_change) {
+test(should_convert_PL_time_near_spring_time_change) {
   // given
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
-  unsigned long expectedSecondsUTC = 1580263140;
 
-  // UTC time difference is 2 minutes
-  LocalDateTime beforePL = pl.fromUtc(2020, 1, 29, 0, 59, 0);
-  LocalDateTime afterPL = pl.fromUtc(2020, 1, 29, 1, 1, 0);
+  // 2020-01-29, 00:59:00 UTC
+  unsigned long utcBefore = 1580259540ul;
+  LocalDateTime beforePL = pl.fromUtc(utcBefore);
+  // 2020-01-29, 01:01:00 UTC
+  unsigned long utcAfter = 1580259660ul;
+  LocalDateTime afterPL = pl.fromUtc(utcAfter);
 
-  // but local time difference should be 1 hour and 2 minutes
-  assertEqual(beforePL.getLocalSeconds(), expectedSecondsUTC);
-  assertEqual(afterPL.getLocalSeconds(), expectedSecondsUTC + 2 * 60);
-}
-
-// in March we change the clock from 2 AM to 3 AM
-test(pl_conversion_near_spring_time_change_2020) {
-  LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
-  LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
-
-  // local time before 1 AM UTC (before 2 AM CET)
-  LocalDateTime beforeUTC = utc.fromUtc(2020, 3, 29, 0, 59, 0);
-  LocalDateTime beforePL = pl.fromUtc(2020, 3, 29, 0, 59, 0);
-
-  assertEqual(beforePL.getLocalSeconds(), beforeUTC.getLocalSeconds() + 3600);
-  // local time after 1 AM UTC (after 3 AM CET)
-  LocalDateTime afterUTC = utc.fromUtc(2020, 3, 29, 1, 1, 0);
-  LocalDateTime afterPL = pl.fromUtc(2020, 3, 29, 1, 1, 0);
-  assertEqual(afterPL.getLocalSeconds(), afterUTC.getLocalSeconds() + 7200);
+  assertEqual(beforePL.getLocalSeconds(), utcBefore + 3600);
+  assertEqual(afterPL.getLocalSeconds(), utcAfter + 7200);
 }
 
 // in October we change the clock from 3 AM to 2 AM
-test(pl_conversion_near_autumn_time_change) {
+test(should_convert_PL_time_near_autumn_time_change) {
   // given
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
-  unsigned long expectedSecondsUTC = 1603594740;
 
-  // UTC time difference is 1 hour and 3 minutes
-  LocalDateTime beforePL = pl.fromUtc(2020, 10, 25, 0, 59, 0);
-  LocalDateTime afterPL = pl.fromUtc(2020, 10, 25, 2, 2, 0);
+  // 2020-10-25, 00:59:00 UTC
+  unsigned long utcBefore = 1603587540ul;
+  LocalDateTime beforePL = pl.fromUtc(utcBefore);
+  // 2020-10-25, 02:01:00 UTC
+  unsigned long utcAfter = 1603587660ul;
+  LocalDateTime afterPL = pl.fromUtc(utcAfter);
 
-  // but local time difference is only 3 minutes
-  assertEqual(beforePL.getLocalSeconds(), expectedSecondsUTC);
-  assertEqual(afterPL.getLocalSeconds(), expectedSecondsUTC + 3 * 60);
+  assertEqual(beforePL.getLocalSeconds(), utcBefore + 7200);
+  assertEqual(afterPL.getLocalSeconds(), utcAfter + 3600);
 }
 
 // in October we change the clock from 3 AM to 2 AM
-test(pl_conversion_near_autumn_time_change_2020) {
-  LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
-  LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
-
-  // local time before 1 AM UTC (before 3 AM CEST)
-  LocalDateTime beforeUTC = utc.fromUtc(2020, 10, 25, 0, 59, 0);
-  LocalDateTime beforePL = pl.fromUtc(2020, 10, 25, 0, 59, 0);
-  assertEqual(beforePL.getLocalSeconds(), beforeUTC.getLocalSeconds() + 7200);
-  // local time after 1 AM UTC (after 2 AM CEST)
-  LocalDateTime afterUTC = utc.fromUtc(2020, 10, 25, 1, 1, 0);
-  LocalDateTime afterPL = pl.fromUtc(2020, 10, 25, 1, 1, 0);
-  assertEqual(afterPL.getLocalSeconds(), afterUTC.getLocalSeconds() + 3600);
-}
-
-// in October we change the clock from 3 AM to 2 AM
-test(pl_time_increase_near_autumn_time_change_2022) {
+test(
+    should_convert_to_PL_time_and_return_time_fragments_near_autumn_time_change_2022) {
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
 
   // 2022-10-30, 00:00:00 UTC
-  // 2022-10-30, 02:00:00 Warsaw time (CEST +2)
-  unsigned long zero = 1667088000;
-
-  unsigned long zeroPlusTwoHours = zero + (2 * 3600);
-  LocalDateTime tested = pl.fromUtc(zeroPlusTwoHours);
+  unsigned long utcMidnight = 1667088000;
+  // 2022-10-30, 02:00:00 UTC
+  unsigned long utcMidnightPlusTwoHours = utcMidnight + (2 * 3600);
+  LocalDateTime tested = pl.fromUtc(utcMidnightPlusTwoHours);
 
   // Two hours later we should have 03:00:00 Warsaw time (CET +1)
   assertEqual(tested.getLocalTimeFragment(HOURS), 3);
@@ -141,7 +108,7 @@ test(pl_time_increase_near_autumn_time_change_2022) {
   assertEqual(tested.getLocalTimeFragment(SECONDS), 0);
 }
 
-test(local_date_get_time_fragments_at_epoch_start_utc) {
+test(should_return_time_fragments_at_epoch_start_UTC) {
   LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
 
   // epoch start
@@ -151,7 +118,7 @@ test(local_date_get_time_fragments_at_epoch_start_utc) {
   assertEqual(utcEpochStart.getLocalTimeFragment(SECONDS), 0);
 }
 
-test(local_date_get_time_fragments_at_epoch_start_pl) {
+test(local_date_get_time_fragments_at_epoch_start_PL) {
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
 
   // epoch start
@@ -161,18 +128,18 @@ test(local_date_get_time_fragments_at_epoch_start_pl) {
   assertEqual(plEpochStart.getLocalTimeFragment(SECONDS), 0);
 }
 
-test(local_date_get_time_fragments_at_valentines_utc) {
+test(should_get_time_fragments_at_valentines_UTC) {
   LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
-  LocalDateTime valentines = utc.fromUtc(2022, 2, 14, 12, 34, 56);
+  LocalDateTime valentines = utc.fromUtc(valentinesUTCSecond);
 
   assertEqual(valentines.getLocalTimeFragment(HOURS), 12);
   assertEqual(valentines.getLocalTimeFragment(MINUTES), 34);
   assertEqual(valentines.getLocalTimeFragment(SECONDS), 56);
 }
 
-test(local_date_get_time_fragments_at_valentines_pl) {
+test(should_get_time_fragments_at_valentines_pl) {
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
-  LocalDateTime valentines = pl.fromUtc(2022, 2, 14, 12, 34, 56);
+  LocalDateTime valentines = pl.fromUtc(valentinesUTCSecond);
 
   // noon in UTC on valentines day is 1 pm in Poland
   assertEqual(valentines.getLocalTimeFragment(HOURS), 13);
@@ -182,9 +149,8 @@ test(local_date_get_time_fragments_at_valentines_pl) {
 
 test(local_date_get_time_fragments_utc_increased_seconds) {
   LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
-  unsigned long epochSeconds = 9876543210;
-  LocalDateTime original = utc.fromUtc(epochSeconds);
-  LocalDateTime increased = utc.fromUtc(epochSeconds + 1);
+  LocalDateTime original = utc.fromUtc(valentinesUTCSecond);
+  LocalDateTime increased = utc.fromUtc(valentinesUTCSecond + 1);
 
   assertEqual(original.getLocalTimeFragment(SECONDS) + 1,
               increased.getLocalTimeFragment(SECONDS));
@@ -192,9 +158,8 @@ test(local_date_get_time_fragments_utc_increased_seconds) {
 
 test(local_date_get_time_fragments_utc_increased_minutes) {
   LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
-  unsigned long epochSeconds = 9876543210;
-  LocalDateTime original = utc.fromUtc(epochSeconds);
-  LocalDateTime increased = utc.fromUtc(epochSeconds + 60);
+  LocalDateTime original = utc.fromUtc(valentinesUTCSecond);
+  LocalDateTime increased = utc.fromUtc(valentinesUTCSecond + 60);
 
   assertEqual(original.getLocalTimeFragment(MINUTES) + 1,
               increased.getLocalTimeFragment(MINUTES));
@@ -202,9 +167,8 @@ test(local_date_get_time_fragments_utc_increased_minutes) {
 
 test(local_date_get_time_fragments_utc_increased_hours) {
   LocalDateTimeConverter utc = LocalDateTimeConverter::UTC;
-  unsigned long epochSeconds = 9876543210;
-  LocalDateTime original = utc.fromUtc(epochSeconds);
-  LocalDateTime increased = utc.fromUtc(epochSeconds + 3600);
+  LocalDateTime original = utc.fromUtc(valentinesUTCSecond);
+  LocalDateTime increased = utc.fromUtc(valentinesUTCSecond + 3600);
 
   assertEqual(original.getLocalTimeFragment(HOURS) + 1,
               increased.getLocalTimeFragment(HOURS));
@@ -212,9 +176,8 @@ test(local_date_get_time_fragments_utc_increased_hours) {
 
 test(local_date_get_time_fragments_pl_increased_seconds) {
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
-  unsigned long epochSeconds = 9876543210;
-  LocalDateTime original = pl.fromUtc(epochSeconds);
-  LocalDateTime increased = pl.fromUtc(epochSeconds + 1);
+  LocalDateTime original = pl.fromUtc(valentinesUTCSecond);
+  LocalDateTime increased = pl.fromUtc(valentinesUTCSecond + 1);
 
   assertEqual(original.getLocalTimeFragment(SECONDS) + 1,
               increased.getLocalTimeFragment(SECONDS));
@@ -222,9 +185,8 @@ test(local_date_get_time_fragments_pl_increased_seconds) {
 
 test(local_date_get_time_fragments_pl_increased_minutes) {
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
-  unsigned long epochSeconds = 9876543210;
-  LocalDateTime original = pl.fromUtc(epochSeconds);
-  LocalDateTime increased = pl.fromUtc(epochSeconds + 60);
+  LocalDateTime original = pl.fromUtc(valentinesUTCSecond);
+  LocalDateTime increased = pl.fromUtc(valentinesUTCSecond + 60);
 
   assertEqual(original.getLocalTimeFragment(MINUTES) + 1,
               increased.getLocalTimeFragment(MINUTES));
@@ -232,9 +194,8 @@ test(local_date_get_time_fragments_pl_increased_minutes) {
 
 test(local_date_get_time_fragments_pl_increased_hours) {
   LocalDateTimeConverter pl = LocalDateTimeConverter::PL;
-  unsigned long epochSeconds = 9876543210;
-  LocalDateTime original = pl.fromUtc(epochSeconds);
-  LocalDateTime increased = pl.fromUtc(epochSeconds + 3600);
+  LocalDateTime original = pl.fromUtc(valentinesUTCSecond);
+  LocalDateTime increased = pl.fromUtc(valentinesUTCSecond + 3600);
 
   assertEqual(original.getLocalTimeFragment(HOURS) + 1,
               increased.getLocalTimeFragment(HOURS));


### PR DESCRIPTION
Method that converted UTC time by provided

- year
- month
- day
- hour
- minute
- seconds

was only used in tests and can be removed.